### PR TITLE
Interest-cohort does not have any effect on Topics API

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,7 @@ The topics will be inferred by the browser. The browser will leverage a classifi
 * If the user doesn’t have enough browsing history to create 5 topics:
     * The remaining topics will be chosen uniformly at random. 
     * This helps privacy without really hurting utility (e.g., it doesn't introduce a bunch of noise into the system since topics are filtered on whether the caller saw the user visit the topic).
-* A site can forbid topic calculation on a page via the following permission policy header:
-    * `Permissions-Policy: browsing-topics=()`
-    * Note: The old `Permissions-Policy: interest-cohort=()` from FLoC will also forbid topic calculation.
+* A site can forbid topic calculation on a page via the following permission policy header: `Permissions-Policy: browsing-topics=()`.
 
 
 ## Privacy goals


### PR DESCRIPTION
The document says:
> Note: The old Permissions-Policy: `interest-cohort=()` from FLoC will also forbid topic calculation.

Unfortunately, this is not true, since Chromium removed `interest-cohort` directive. This PR updates the explainer doc to match the current Chromium implementation.

Related:
 - https://github.com/GoogleChrome/developer.chrome.com/pull/2297
 - https://github.com/GoogleChrome/developer.chrome.com/issues/2296
 - https://github.com/chromium/chromium/commit/9255aecd4114c0b3da4016f641316367112adb53#diff-f28d1874df346cd0b53f62e5f15bc4b6bbc324721bb3cad80cfa1c6a6c75d0a6 - this commit removed `interest-cohort` directive from Chromium