### PR TITLE
Remove non-empty requirement for the topics header

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The topics will be inferred by the browser. The browser will leverage a classifi
 * Topics can also be retrieved via request headers, and marked as observed and eligible for topics calculation via response headers.
     * This is likely to be considerably more performant than using the JavaScript API.
     * The request header can be sent along with fetch requests via specifying an option: `fetch(<url>, {browsingTopics: true})`.
-    * The request header will be sent on document requests when the list of topics is non-empty and the request is allowable (e.g., permission policy allows it, the context is secure, etc.).
+    * The request header will be sent on document requests when the request is allowable (e.g., permission policy allows it, the context is secure, etc.).
     * Redirects will be followed, and the topics sent in the redirect request will be specific to the redirect url.
     * The request header will not modify state for the caller unless there is a corresponding response header. That is, the topic of the page won't be considered observed, nor will it affect the user's topic calculation for the next epoch. 
     * The response header will only be honored if the corresponding request included the topics header (or would have included the header if it wasn't empty).


### PR DESCRIPTION
The topics header will be sent as long as its eligible for topics, regardless of if the result is empty or not