### PR TITLE
Remove redundant version fields in the header to make it shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ The topics will be inferred by the browser. The browser will leverage a classifi
     * The request header will not modify state for the caller unless there is a corresponding response header. That is, the topic of the page won't be considered observed, nor will it affect the user's topic calculation for the next epoch. 
     * The response header will only be honored if the corresponding request included the topics header (or would have included the header if it wasn't empty).
     * The registrable domain used for topic observation is that of the url of the request.
-    * Example request header: `Sec-Browsing-Topics: 123;model=1;taxonomy=1;version=2, 2;model=1;taxonomy=1;version=2`
+    * Example request header: `Sec-Browsing-Topics: 123;v=chrome.1:1:2, 2`
         * This example has two topics, 123 and 2, along with their version information.
+        * The version information for topic 2 is omitted, as it's identical with the version of the first returned topic.
     * Example response header: `Observe-Browsing-Topics: ?1`
     
 * For each week, the user’s top 5 topics are calculated using browsing information local to the browser. 

--- a/spec.bs
+++ b/spec.bs
@@ -493,13 +493,12 @@ spec: html; urlPrefix: https://www.rfc-editor.org/rfc/
       1. If the user preference setting disallows the access to topics from |topicsCallerContext|'s [=topics caller context/caller origin=] or |topicsCallerContext|'s [=topics caller context/top level context domain=], then return.
       1. Let |topics| be the result from running the [=calculate the topics for caller=] algorithm, with |topicsCallerContext| as input.
       1. Let |headerStructuredFields| be an empty Structured Fields <a href="https://www.rfc-editor.org/rfc/rfc8941.html#name-lists">List</a>.
+      1. Let |lastVersion| be null.
       1. For each |topic| in |topics|:
           1. Let |topicItem| be a Structured Fields <a href="https://www.rfc-editor.org/rfc/rfc8941.html#name-integers">Integer</a> with value |topic|["{{BrowsingTopic/topic}}"].
           1. Let |topicParameters| be an empty Structured Fields <a href="https://www.rfc-editor.org/rfc/rfc8941.html#name-parameters">Parameters</a>.
-          1. Set |topicParameters|["<code>version</code>"] to |topic|["{{BrowsingTopic/version}}"].
-          1. Set |topicParameters|["<code>config_version</code>"] to |topic|["{{BrowsingTopic/configVersion}}"].
-          1. Set |topicParameters|["<code>model_version</code>"] to |topic|["{{BrowsingTopic/modelVersion}}"].
-          1. Set |topicParameters|["<code>taxonomy_version</code>"] to |topic|["{{BrowsingTopic/taxonomyVersion}}"].
+          1. If |lastVersion| is null, or if |lastVersion| does not equal |topic|["{{BrowsingTopic/version}}"], then set |topicParameters|["<code>v</code>"] to |topic|["{{BrowsingTopic/version}}"].
+          1. Set |lastVersion| to |topic|["{{BrowsingTopic/version}}"].
           1. Associate |topicParameters| with |topicItem|.
           1. Insert |topicItem| to |headerStructuredFields|.
       1. [=Set a structured field value=] given ([:Sec-Browsing-Topics:], |headerStructuredFields|) in |request|'s [=request/header list=].


### PR DESCRIPTION
- Only keep the "version" (renamed to "v") field and remove the redundant config_version, model_version, and taxonomy_version.
- Also, if a version for a topic is the same as before, omit it in the structured field param.