### PR TITLE
Spec: Switch to patcg-id UD

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
 Title: Topics API
-Status: w3c/CG-DRAFT
+Status: UD
 ED: https://github.com/patcg-individual-drafts/topics
 Shortname: topics
 Level: 1
@@ -9,7 +9,7 @@ Editor: Yao Xiao, Google, yaoxia@chromium.org
 Editor: Josh Karlin, Google, jkarlin@chromium.org
 Abstract: This specification describes a method that could enable ad-targeting based on a person's general browsing interests without exposing their exact browsing history.
 !Participate: <a href="https://github.com/patcg-individual-drafts/topics">GitHub patcg-individual-drafts/topics</a> (<a href="https://github.com/patcg-individual-drafts/topics/issues/new">new issue</a>, <a href="https://github.com/patcg-individual-drafts/topics/issues?state=open">open issues</a>)
-Group: patcg
+Group: patcg-id
 Repository: patcg-individual-drafts/topics
 Markup Shorthands: markdown yes
 </pre>


### PR DESCRIPTION
Per discussion in https://github.com/speced/bikeshed-boilerplate/pull/43, changes the group to "patcg-id" and the status to "UD" (Unofficial Draft).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/topics/pull/234.html" title="Last updated on Aug 18, 2023, 6:46 PM UTC (4cccfbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/topics/234/a000806...4cccfbb.html" title="Last updated on Aug 18, 2023, 6:46 PM UTC (4cccfbb)">Diff</a>