### PR TITLE
Sending Topics with <img>

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The topics will be inferred by the browser. The browser will leverage a classifi
     * This is likely to be considerably more performant than using the JavaScript API.
     * The request header can be sent along with fetch requests via specifying an option: `fetch(<url>, {browsingTopics: true})`.
     * The request header will be sent on document requests via specifying an attribute: `<iframe src=[url] browsingtopics></iframe>`, or via the equivalent IDL attribute: `iframe.browsingTopics = true`.
+    * The request header will be sent on image requests via specifying an attribute: `<img src=[url] browsingtopics></img>`, or via the equivalent IDL attribute: `img.browsingTopics = true`.
     * Redirects will be followed, and the topics sent in the redirect request will be specific to the redirect url.
     * The request header will not modify state for the caller unless there is a corresponding response header. That is, the topic of the page won't be considered observed, nor will it affect the user's topic calculation for the next epoch. 
     * The response header will only be honored if the corresponding request included the topics header (or would have included the header if it wasn't empty).


### PR DESCRIPTION
The Topics API offers the option of using request headers to retrieve browsing topics, which is more performant than retrieving them via Javascript (`document.browsingTopics()`). Currently, the request header can be sent along with a fetch request by specifying an option (`fetch(<url>, {browsingTopics: true})`) or sent on document requests by specifying an attribute on an iframe (`<iframe src=[url] browsingtopics></iframe>`). This proposal is to add the option of sending a request header on img requests by specifying an attribute: `<img src=[url] browsingtopics>`. The change will offer an alternative approach to access topics.